### PR TITLE
Remove polyline/extrude

### DIFF
--- a/src/dactyl_keyboard/dactyl_manuform.py
+++ b/src/dactyl_keyboard/dactyl_manuform.py
@@ -377,15 +377,12 @@ def sa_cap(Usize=1):
         pl2 = 6
         pw2 = 11
 
-    k1 = polyline([(bw2, bl2), (bw2, -bl2), (-bw2, -bl2), (-bw2, bl2), (bw2, bl2)])
-    k1 = extrude_poly(outer_poly=k1, height=0.1)
+    k1 = box(bw2 * 2, bl2 * 2, 0.1)
     k1 = translate(k1, (0, 0, 0.05))
-    k2 = polyline([(pw2, pl2), (pw2, -pl2), (-pw2, -pl2), (-pw2, pl2), (pw2, pl2)])
-    k2 = extrude_poly(outer_poly=k2, height=0.1)
+    k2 = box(pw2 * 2, pl2 * 2, 0.1)
     k2 = translate(k2, (0, 0, 12.0))
     if m > 0:
-        m1 = polyline([(m, m), (m, -m), (-m, -m), (-m, m), (m, m)])
-        m1 = extrude_poly(outer_poly=m1, height=0.1)
+        m1 = box(m * 2, m * 2, 0.1)
         m1 = translate(m1, (0, 0, 6.0))
         key_cap = hull_from_shapes((k1, k2, m1))
     else:
@@ -412,14 +409,10 @@ def choc_cap(Usize=1):
         pt = 1.5
         gap = 1.5
 
-    k1 = polyline([(bw2, bl2), (bw2, -bl2), (-bw2, -bl2), (-bw2, bl2), (bw2, bl2)])
-    k1 = extrude_poly(outer_poly=k1, height=0.1)
-    k1 = translate(k1, (0, 0, 0.05))
-    k2 = polyline([(bw2, bl2), (bw2, -bl2), (-bw2, -bl2), (-bw2, bl2), (bw2, bl2)])
-    k2 = extrude_poly(outer_poly=k2, height=0.1)
-    k2 = translate(k2, (0, 0, 0.05+bt))
-    k3 = polyline([(pw2, pl2), (pw2, -pl2), (-pw2, -pl2), (-pw2, pl2), (pw2, pl2)])
-    k3 = extrude_poly(outer_poly=k3, height=0.1)
+    k_box = box(bw2 * 2, bl2 * 2, 0.1)
+    k1 = translate(k_box, (0, 0, 0.05))
+    k2 = translate(k_box, (0, 0, 0.05+bt))
+    k3 = box(pw2 * 2, pl2 * 2, 0.1)
     k3 = translate(k3, (0, 0, 0.05+bt+pt))
     key_cap = hull_from_shapes((k1, k2, k3))
 

--- a/src/dactyl_keyboard/helpers_cadquery.py
+++ b/src/dactyl_keyboard/helpers_cadquery.py
@@ -195,27 +195,6 @@ def bottom_hull(p, height=0.001):
     return shape
 
 
-def polyline(point_list):
-    return cq.Workplane('XY').polyline(point_list)
-
-
-# def project_to_plate():
-#     square = cq.Workplane('XY').rect(1000, 1000)
-#     for wire in square.wires().objects:
-#         plane = cq.Workplane('XY').add(cq.Face.makeFromWires(wire))
-
-
-def extrude_poly(outer_poly, inner_polys=None, height=1):  # vector=(0,0,1)):
-    outer_wires = cq.Wire.assembleEdges(outer_poly.edges().objects)
-    inner_wires = []
-    if inner_polys is not None:
-        for item in inner_polys:
-            inner_wires.append(cq.Wire.assembleEdges(item.edges().objects))
-
-    return cq.Workplane('XY').add(
-        cq.Solid.extrudeLinear(outerWire=outer_wires, innerWires=inner_wires, vecNormal=cq.Vector(0, 0, height)))
-
-
 def import_resource(parts_path: resources.abc.Traversable, fname: str, convexity=None):
     logging.info("IMPORTING FROM %s", fname)
     with resources.as_file(parts_path.joinpath(fname + ".step")) as extracted:

--- a/src/dactyl_keyboard/helpers_solid.py
+++ b/src/dactyl_keyboard/helpers_solid.py
@@ -130,22 +130,6 @@ def bottom_hull(p, height=0.001):
     return shape
 
 
-def polyline(point_list):
-    return sl.polygon(point_list)
-
-
-# def project_to_plate():
-#     square = cq.Workplane('XY').rect(1000, 1000)
-#     for wire in square.wires().objects:
-#         plane = cq.Workplane('XY').add(cq.Face.makeFromWires(wire))
-
-def extrude_poly(outer_poly, inner_polys=None, height=1):
-    if inner_polys is not None:
-        return sl.linear_extrude(height=height, twist=0, convexity=0, center=True)(outer_poly, *inner_polys)
-    else:
-        return sl.linear_extrude(height=height, twist=0, convexity=0, center=True)(outer_poly)
-
-
 def import_resource(parts_path: resources.abc.Traversable, fname: str, convexity=2):
     logging.info("IMPORTING FROM %s", fname)
     with resources.as_file(parts_path.joinpath(fname + ".stl")) as extracted:


### PR DESCRIPTION
When creating keycaps, they are created by creating two (or three) 2D wires, extruding them a bit, then creating a convex hull from the mesh.

We can skip the 2D wires and extrude, and instead just create boxes.